### PR TITLE
Fix/studentmodel constructor arg order

### DIFF
--- a/LMS/.mvn/wrapper/maven-wrapper.properties:Zone.Identifier
+++ b/LMS/.mvn/wrapper/maven-wrapper.properties:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\mario\Downloads\Repo 4.zip

--- a/LMS/src/main/java/com/example/LMS/models/StudentModel.java
+++ b/LMS/src/main/java/com/example/LMS/models/StudentModel.java
@@ -14,8 +14,8 @@ public class StudentModel extends User {
         super(id, name, password, role, email);
     }
 
-    public StudentModel(String name, String role, String password, String email) {
-        super(name, role, password, email);
+    public StudentModel(String name, String password, String role,String email) {
+        super(name, password, role, email);
     }
 
     public StudentModel(Integer id, String email, String name) {

--- a/LMS/src/main/java/com/example/LMS/services/UserService.java
+++ b/LMS/src/main/java/com/example/LMS/services/UserService.java
@@ -56,7 +56,7 @@ public class UserService {
 
         user.setPassword(passwordEncoder.encode(user.getPassword()));
         if(Objects.equals(user.getRole(), "ROLE_STUDENT")){
-            StudentModel student = new StudentModel(user.getName(),  user.getRole(), user.getPassword(),user.getEmail());
+            StudentModel student = new StudentModel(user.getName(), user.getPassword() ,user.getRole(),user.getEmail());
             Profile profile = new Profile(student);
             studentRepository.save(student);
             profileRepository.save(profile);


### PR DESCRIPTION
Bug Fix

Location:`StudentModel.java` – Constructor

Issue:
The constructor arguments in `StudentModel` were forwarded to the `User` superclass in the wrong order. This led to:
- Password and role being incorrectly assigned
- Login failures and incorrect user data storage

Fix:
- Corrected the order of arguments passed to the `super()` call in the constructor to match the `User` constructor.

Type: Intention-Based SM: Corrective

This fix resolves:
- Incorrect login credentials being saved
- Broken role recognition for student accounts
