### PR TITLE
Fix/user getauthorities role prefix

### DIFF
--- a/LMS/.mvn/wrapper/maven-wrapper.properties:Zone.Identifier
+++ b/LMS/.mvn/wrapper/maven-wrapper.properties:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\mario\Downloads\Repo 4.zip

--- a/LMS/src/main/java/com/example/LMS/models/User.java
+++ b/LMS/src/main/java/com/example/LMS/models/User.java
@@ -74,13 +74,11 @@ public class User implements UserDetails {
     }
 
 
-
-    @Override
+@Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(role));
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.toUpperCase()));
     }
-
-
+    
     @Override
     public String getUsername() {
         return email;


### PR DESCRIPTION
🐛 Bug Fix

Location: `User.java` – `getAuthorities()` method

Issue:
The `getAuthorities()` method returned role names in plain format (e.g., `"STUDENT"`), which broke access control annotations like `@PreAuthorize("hasRole('STUDENT')")`.

Spring Security expects roles to be prefixed with `"ROLE_"`, e.g., `"ROLE_STUDENT"`.

Fix:
- Updated the return logic to prefix the role with `"ROLE_"` before wrapping it in a `SimpleGrantedAuthority`.

Type: Intention-Based SM: Corrective

 This fix resolves:
- Authorization failures due to invalid role format
- Misbehavior of Spring Security’s role-based access control
